### PR TITLE
Added test: Throws exception when using wrong id

### DIFF
--- a/src/test/java/com/example/grupparbetetodo/service/TodoServiceTest.java
+++ b/src/test/java/com/example/grupparbetetodo/service/TodoServiceTest.java
@@ -136,5 +136,11 @@ public class TodoServiceTest {
 
     }
 
+    @Test
+    void findTodobyIdThrows(){
+
+        assertThrows(NoSuchElementException.class, ()-> todoService.findById(5L));
+    }
+
 
 }


### PR DESCRIPTION
added a test that throws an exception when the user tries to find a Todo with a non-existing ID